### PR TITLE
chore: scaffold nextjs app layout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+FEATURE_PROJECTS=false

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.next
+out
+.env
+.env.local
+.env.production
+
+# others
+pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # FS-Contracting CRM
-Prototype CRM system for FS-Contracting N.V.
+
+This repository contains a minimal prototype scaffold for the FS-Contracting N.V. CRM. It includes a Next.js 14 App Router structure with a persistent sidebar layout and placeholder pages for future features.
+
+## Development
+
+Install dependencies and start the dev server:
+
+```bash
+pnpm install
+pnpm dev
+```
+
+Environment variables:
+
+- `FEATURE_PROJECTS` – enable the Projects page in navigation.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "fs-contracting-crm",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "lucide-react": "0.321.0",
+    "zustand": "4.4.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.8.0",
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
+    "autoprefixer": "10.4.14",
+    "postcss": "8.4.24",
+    "tailwindcss": "3.3.3",
+    "typescript": "5.2.2",
+    "eslint": "8.48.0",
+    "eslint-config-next": "14.1.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/app/(app)/bankboek/page.tsx
+++ b/src/app/(app)/bankboek/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 className="text-2xl font-bold">Bankboek</h1>;
+}

--- a/src/app/(app)/clients/page.tsx
+++ b/src/app/(app)/clients/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 className="text-2xl font-bold">Clients</h1>;
+}

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 className="text-2xl font-bold">Dashboard</h1>;
+}

--- a/src/app/(app)/invoices/page.tsx
+++ b/src/app/(app)/invoices/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 className="text-2xl font-bold">Invoices</h1>;
+}

--- a/src/app/(app)/kasboek/page.tsx
+++ b/src/app/(app)/kasboek/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 className="text-2xl font-bold">Kasboek</h1>;
+}

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,0 +1,15 @@
+import LeftSidebar from '@/components/shell/LeftSidebar';
+import TopBar from '@/components/shell/TopBar';
+import '@/styles/globals.css';
+
+export default function AppLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex h-screen w-screen bg-neutral-900 text-neutral-50">
+      <LeftSidebar />
+      <div className="flex flex-1 flex-col">
+        <TopBar />
+        <main className="flex-1 overflow-y-auto p-4">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/projects/page.tsx
+++ b/src/app/(app)/projects/page.tsx
@@ -1,0 +1,9 @@
+import { FEATURE_PROJECTS } from '@/lib/featureFlags';
+import { redirect } from 'next/navigation';
+
+export default function ProjectsPage() {
+  if (!FEATURE_PROJECTS) {
+    redirect('/dashboard');
+  }
+  return <h1 className="text-2xl font-bold">Projects (coming soon)</h1>;
+}

--- a/src/app/(app)/reports/page.tsx
+++ b/src/app/(app)/reports/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 className="text-2xl font-bold">Reports</h1>;
+}

--- a/src/app/(app)/services/page.tsx
+++ b/src/app/(app)/services/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 className="text-2xl font-bold">Services</h1>;
+}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 className="text-2xl font-bold">Settings</h1>;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'FS-Contracting CRM',
+  description: 'CRM prototype',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Home() {
+  redirect('/dashboard');
+}

--- a/src/components/shell/LeftSidebar.tsx
+++ b/src/components/shell/LeftSidebar.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import {
+  LayoutDashboard,
+  Wallet,
+  Banknote,
+  FileText,
+  Users,
+  Wrench,
+  BarChart3,
+  Settings,
+  FolderKanban
+} from 'lucide-react';
+import { useSidebar } from '@/lib/sidebarStore';
+import { FEATURE_PROJECTS } from '@/lib/featureFlags';
+
+interface Item {
+  href: string;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+}
+
+const baseItems: Item[] = [
+  { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
+  { href: '/kasboek', label: 'Kasboek', icon: Wallet },
+  { href: '/bankboek', label: 'Bankboek', icon: Banknote },
+  { href: '/invoices', label: 'Invoices', icon: FileText },
+  { href: '/clients', label: 'Clients', icon: Users },
+  { href: '/services', label: 'Services', icon: Wrench },
+  { href: '/reports', label: 'Reports', icon: BarChart3 },
+  { href: '/settings', label: 'Settings', icon: Settings }
+];
+
+if (FEATURE_PROJECTS) {
+  baseItems.splice(6, 0, { href: '/projects', label: 'Projects', icon: FolderKanban });
+}
+
+export default function LeftSidebar() {
+  const pathname = usePathname();
+  const { collapsed, toggle } = useSidebar();
+
+  return (
+    <aside
+      className={`flex h-full flex-col bg-neutral-800 p-2 transition-all duration-300 ${
+        collapsed ? 'w-16' : 'w-56'
+      }`}
+    >
+      <nav className="flex-1 space-y-1">
+        {baseItems.map((item) => {
+          const Icon = item.icon;
+          const active = pathname === item.href;
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`flex items-center rounded px-3 py-2 text-sm hover:bg-neutral-700 ${
+                active ? 'bg-neutral-700 font-medium' : ''
+              }`}
+            >
+              <Icon className="h-5 w-5" />
+              {!collapsed && <span className="ml-3">{item.label}</span>}
+            </Link>
+          );
+        })}
+      </nav>
+      <button
+        onClick={toggle}
+        className="mt-auto rounded px-3 py-2 text-sm hover:bg-neutral-700"
+        aria-label="Toggle sidebar"
+      >
+        {collapsed ? '»' : '«'}
+      </button>
+    </aside>
+  );
+}

--- a/src/components/shell/TopBar.tsx
+++ b/src/components/shell/TopBar.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+export default function TopBar() {
+  return (
+    <header className="flex items-center justify-between border-b border-neutral-700 bg-neutral-800 px-4 py-2">
+      <input
+        type="text"
+        placeholder="Search..."
+        aria-label="Search"
+        className="w-full max-w-xs rounded bg-neutral-700 px-2 py-1 text-sm"
+      />
+      <div className="ml-auto flex items-center space-x-3">
+        <div className="h-8 w-8 rounded-full bg-neutral-600" />
+      </div>
+    </header>
+  );
+}

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -1,0 +1,1 @@
+export const FEATURE_PROJECTS = process.env.FEATURE_PROJECTS === 'true';

--- a/src/lib/sidebarStore.ts
+++ b/src/lib/sidebarStore.ts
@@ -1,0 +1,18 @@
+'use client';
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface SidebarState {
+  collapsed: boolean;
+  toggle: () => void;
+}
+
+export const useSidebar = create<SidebarState>()(
+  persist(
+    (set) => ({
+      collapsed: false,
+      toggle: () => set((state) => ({ collapsed: !state.collapsed })),
+    }),
+    { name: 'sidebar' }
+  )
+);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --accent: theme('colors.emerald.500');
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,22 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: "class",
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        accent: {
+          DEFAULT: "var(--accent)"
+        }
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- setup Next.js 14 scaffold using TypeScript and Tailwind
- add persistent sidebar and top bar layout with placeholder pages
- wire feature flag to optionally expose Projects route

## Testing
- `pnpm install` (fails: GET https://registry.npmjs.org/@types%2Freact: Forbidden - 403)
- `pnpm lint` (fails: next: not found)
- `pnpm run test` (fails: Missing script: test)


------
https://chatgpt.com/codex/tasks/task_e_68c5c6d7d6e88328b630bff71ae86731